### PR TITLE
Eleveldb version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,3 @@
+{deps, [
+       {eleveldb, ".*", {git, "git://github.com/SyncFree/eleveldb", {branch, "antidote_comparator"}}}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
        {eleveldb, ".*", {git, "git://github.com/SyncFree/eleveldb", {branch, "antidote_comparator"}}},
-       {antidote_utils, ".*", {git, "git://github.com/SyncFree/antidote_utils", {branch, "add_op_snap"}}}
+       {antidote_utils, ".*", {git, "git://github.com/SyncFree/antidote_utils", {branch, "additions_for_antidote_db"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
        {eleveldb, ".*", {git, "git://github.com/SyncFree/eleveldb", {branch, "antidote_comparator"}}},
-       {antidote_utils, ".*", {git, "git://github.com/SyncFree/antidote_utils", {branch, "master"}}}
+       {antidote_utils, ".*", {git, "git://github.com/SyncFree/antidote_utils", {branch, "add_op_snap"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
 {deps, [
-       {eleveldb, ".*", {git, "git://github.com/SyncFree/eleveldb", {branch, "antidote_comparator"}}}
+       {eleveldb, ".*", {git, "git://github.com/SyncFree/eleveldb", {branch, "antidote_comparator"}}},
+       {antidote_utils, ".*", {git, "git://github.com/SyncFree/antidote_utils", {branch, "master"}}}
 ]}.

--- a/src/antidote_db.app.src
+++ b/src/antidote_db.app.src
@@ -1,0 +1,13 @@
+{application, antidote_db,
+ [
+  {description, "Antidote DataBase application"},
+  {vsn, "1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib,
+                  eleveldb
+                 ]},
+  {mod, { antidote_db, []}},
+  {env, []}
+ ]}.

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -1,0 +1,79 @@
+-module(antidote_db).
+
+-export([
+    new/1,
+    get/2,
+    put/3,
+    close_and_destroy/2,
+    close/1,
+    fold/3,
+    fold_keys/3,
+    is_empty/1,
+    delete/2,
+    repair/1]).
+
+-type antidote_db() :: eleveldb:db_ref().
+
+-export_type([antidote_db/0]).
+
+%% Given a name, returns a new AntidoteDB (ElevelDB)
+%% OpenOptions are set to use Antidote special comparator
+-spec new(atom()) -> {ok, antidote_db()} | {error, any()}.
+new(Name) ->
+    eleveldb:open(Name, [{create_if_missing, true}, {antidote, true}]).
+
+%% Closes and destroys the given base
+-spec close_and_destroy(antidote_db(), atom()) -> ok | {error, any()}.
+close_and_destroy(AntidoteDB, Name) ->
+    eleveldb:close(AntidoteDB),
+    eleveldb:destroy(Name, []).
+
+-spec close(antidote_db()) -> ok | {error, any()}.
+close(AntidoteDB) ->
+    eleveldb:close(AntidoteDB).
+
+%% @doc returns the value of Key, in the antidote_db
+-spec get(antidote_db(), atom() | binary()) -> term() | not_found.
+get(AntidoteDB, Key) ->
+    AKey = case is_binary(Key) of
+               true -> Key;
+               false -> atom_to_binary(Key, utf8)
+           end,
+    case eleveldb:get(AntidoteDB, AKey, []) of
+        {ok, Res} ->
+            binary_to_term(Res);
+        not_found ->
+            not_found
+    end.
+
+%% @doc puts the Value associated to Key in eleveldb AntidoteDB
+-spec put(antidote_db(), atom() | binary(), any()) -> ok | {error, any()}.
+put(AntidoteDB, Key, Value) ->
+    AKey = case is_binary(Key) of
+               true -> Key;
+               false -> atom_to_binary(Key, utf8)
+           end,
+    ATerm = case is_binary(Value) of
+                true -> Value;
+                false -> term_to_binary(Value)
+            end,
+    eleveldb:put(AntidoteDB, AKey, ATerm, []).
+
+-spec fold(antidote_db(), eleveldb:fold_fun(), any()) -> any().
+fold(AntidoteDB, Fun, Acc0) ->
+    eleveldb:fold(AntidoteDB, Fun, Acc0, []).
+
+-spec fold_keys(antidote_db(), eleveldb:fold_keys_fun(), any()) -> any().
+fold_keys(AntidoteDB, Fun, Acc0) ->
+    eleveldb:fold_keys(AntidoteDB, Fun, Acc0, []).
+
+-spec is_empty(antidote_db()) -> boolean().
+is_empty(AntidoteDB) ->
+    eleveldb:is_empty(AntidoteDB).
+
+repair(Name) ->
+    eleveldb:repair(Name, []).
+
+-spec delete(antidote_db(), binary()) -> ok | {error, any()}.
+delete(AntidoteDB, Key) ->
+    eleveldb:delete(AntidoteDB, Key, []).

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -37,6 +37,10 @@
 
 -export_type([antidote_db/0, antidote_db_type/0]).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 %% Given a name, returns a new AntidoteDB (for now, only ElevelDB is supported)
 %% OpenOptions are set to use Antidote special comparator in the case of Eleveldb
 -spec new(atom(), antidote_db_type()) -> {ok, antidote_db()} | {error, any()}.
@@ -115,3 +119,15 @@ put_op({Type, DB}, Key, VC, Record) ->
     end.
 
 
+-ifdef(TEST).
+
+wrong_types_test() ->
+    ?assertEqual({error, type_not_supported}, new("TEST", type)),
+    ?assertEqual({error, type_not_supported}, close_and_destroy({type, db}, name)),
+    ?assertEqual({error, type_not_supported}, close({type, db})),
+    ?assertEqual({error, type_not_supported}, get_snapshot({type, db}, key, [])),
+    ?assertEqual({error, type_not_supported}, put_snapshot({type, db}, key, [], [])),
+    ?assertEqual({error, type_not_supported}, get_ops({type, db}, key, [], [])),
+    ?assertEqual({error, type_not_supported}, put_op({type, db}, key, [], [])).
+
+-endif.

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -33,11 +33,11 @@ close(AntidoteDB) ->
     eleveldb:close(AntidoteDB).
 
 %% @doc returns the value of Key, in the antidote_db
--spec get(antidote_db(), atom() | binary()) -> term() | not_found.
+-spec get(antidote_db(), any()) -> term() | not_found.
 get(AntidoteDB, Key) ->
     AKey = case is_binary(Key) of
                true -> Key;
-               false -> atom_to_binary(Key, utf8)
+               false -> term_to_binary(Key)
            end,
     case eleveldb:get(AntidoteDB, AKey, []) of
         {ok, Res} ->
@@ -47,11 +47,11 @@ get(AntidoteDB, Key) ->
     end.
 
 %% @doc puts the Value associated to Key in eleveldb AntidoteDB
--spec put(antidote_db(), atom() | binary(), any()) -> ok | {error, any()}.
+-spec put(antidote_db(), any(), any()) -> ok | {error, any()}.
 put(AntidoteDB, Key, Value) ->
     AKey = case is_binary(Key) of
                true -> Key;
-               false -> atom_to_binary(Key, utf8)
+               false -> term_to_binary(Key)
            end,
     ATerm = case is_binary(Value) of
                 true -> Value;

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -27,7 +27,7 @@
     close_and_destroy/2,
     close/1,
     get_snapshot/3,
-    put_snapshot/4,
+    put_snapshot/3,
     get_ops/4,
     put_op/4]).
 
@@ -77,7 +77,7 @@ close({Type, DB}) ->
 %% Gets the most suitable snapshot for Key that has been committed
 %% before CommitTime. If its nothing is found, returns {error, not_found}
 -spec get_snapshot(antidote_db:antidote_db(), key(),
-    snapshot_time()) -> {ok, snapshot(), snapshot_time()} | {error, not_found}.
+    snapshot_time()) -> {ok, #materialized_snapshot{}} | {error, not_found}.
 get_snapshot({Type, DB}, Key, CommitTime) ->
     case Type of
         leveldb ->
@@ -87,12 +87,11 @@ get_snapshot({Type, DB}, Key, CommitTime) ->
     end.
 
 %% Saves the snapshot into AntidoteDB
--spec put_snapshot(antidote_db:antidote_db(), key(), snapshot_time(),
-    snapshot()) -> ok | error.
-put_snapshot({Type, DB}, Key, SnapshotTime, Snapshot) ->
+-spec put_snapshot(antidote_db:antidote_db(), key(), #materialized_snapshot{}) -> ok | error.
+put_snapshot({Type, DB}, Key, Snapshot) ->
     case Type of
         leveldb ->
-            leveldb_wrapper:put_snapshot(DB, Key, SnapshotTime, Snapshot);
+            leveldb_wrapper:put_snapshot(DB, Key, Snapshot);
         _ ->
             {error, type_not_supported}
     end.
@@ -126,7 +125,7 @@ wrong_types_test() ->
     ?assertEqual({error, type_not_supported}, close_and_destroy({type, db}, name)),
     ?assertEqual({error, type_not_supported}, close({type, db})),
     ?assertEqual({error, type_not_supported}, get_snapshot({type, db}, key, [])),
-    ?assertEqual({error, type_not_supported}, put_snapshot({type, db}, key, [], [])),
+    ?assertEqual({error, type_not_supported}, put_snapshot({type, db}, key, [])),
     ?assertEqual({error, type_not_supported}, get_ops({type, db}, key, [], [])),
     ?assertEqual({error, type_not_supported}, put_op({type, db}, key, [], [])).
 

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -26,6 +26,7 @@
     new/2,
     close_and_destroy/2,
     close/1,
+    get_ops_applicable_to_snapshot/3,
     get_snapshot/3,
     put_snapshot/3,
     get_ops/4,
@@ -70,6 +71,16 @@ close({Type, DB}) ->
     case Type of
         leveldb ->
             eleveldb:close(DB);
+        _ ->
+            {error, type_not_supported}
+    end.
+
+-spec get_ops_applicable_to_snapshot(antidote_db:antidote_db(), key(), vectorclock()) ->
+    {ok, #materialized_snapshot{} | not_found, [#log_record{}]}.
+get_ops_applicable_to_snapshot({Type, DB}, Key, VectorClock) ->
+    case Type of
+        leveldb ->
+            leveldb_wrapper:get_ops_applicable_to_snapshot(DB, Key, VectorClock);
         _ ->
             {error, type_not_supported}
     end.

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -6,8 +6,8 @@
     put/3,
     close_and_destroy/2,
     close/1,
-    fold/3,
-    fold_keys/3,
+    fold/4,
+    fold_keys/4,
     is_empty/1,
     delete/2,
     repair/1]).

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(antidote_db).
 
 -export([

--- a/src/antidote_db.erl
+++ b/src/antidote_db.erl
@@ -59,13 +59,13 @@ put(AntidoteDB, Key, Value) ->
             end,
     eleveldb:put(AntidoteDB, AKey, ATerm, []).
 
--spec fold(antidote_db(), eleveldb:fold_fun(), any()) -> any().
-fold(AntidoteDB, Fun, Acc0) ->
-    eleveldb:fold(AntidoteDB, Fun, Acc0, []).
+-spec fold(antidote_db(), eleveldb:fold_fun(), any(), eleveldb:read_options()) -> any().
+fold(AntidoteDB, Fun, Acc0, Opts) ->
+    eleveldb:fold(AntidoteDB, Fun, Acc0, Opts).
 
--spec fold_keys(antidote_db(), eleveldb:fold_keys_fun(), any()) -> any().
-fold_keys(AntidoteDB, Fun, Acc0) ->
-    eleveldb:fold_keys(AntidoteDB, Fun, Acc0, []).
+-spec fold_keys(antidote_db(), eleveldb:fold_keys_fun(), any(), eleveldb:read_options()) -> any().
+fold_keys(AntidoteDB, Fun, Acc0, Opts) ->
+    eleveldb:fold_keys(AntidoteDB, Fun, Acc0, Opts).
 
 -spec is_empty(antidote_db()) -> boolean().
 is_empty(AntidoteDB) ->

--- a/src/antidote_db_sup.erl
+++ b/src/antidote_db_sup.erl
@@ -1,0 +1,26 @@
+-module(antidote_db_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, []} }.

--- a/src/antidote_db_sup.erl
+++ b/src/antidote_db_sup.erl
@@ -1,3 +1,22 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
 -module(antidote_db_sup).
 
 -behaviour(supervisor).

--- a/src/antidote_db_wrapper.erl
+++ b/src/antidote_db_wrapper.erl
@@ -89,16 +89,16 @@ get_ops(AntidoteDB, Key, VCFrom, VCTo) ->
                                 AccIn;
                             false ->
                                 %% check its an op and its commit time is in the required range
-                                case not vectorclock:lt(VC1Dict, VCFromDict) of
+                                case vectorclock:lt(VC1Dict, VCFromDict) of
                                     true ->
+                                        throw({break, AccIn});
+                                    false ->
                                         case (OP == op) of
                                             true ->
                                                 AccIn ++ [binary_to_term(V)];
                                             false ->
                                                 AccIn
-                                        end;
-                                    false ->
-                                        throw({break, AccIn})
+                                        end
                                 end
                         end;
                     false ->

--- a/src/antidote_db_wrapper.erl
+++ b/src/antidote_db_wrapper.erl
@@ -1,0 +1,325 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 SyncFree Consortium.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(antidote_db_wrapper).
+
+-include_lib("antidote_utils/include/antidote_utils.hrl").
+
+-export([get_snapshot/3,
+    put_snapshot/4,
+    get_ops/4,
+    put_op/4]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% Gets the most suitable snapshot for Key that has been committed
+%% before CommitTime. If its nothing is found, returns {error, not_found}
+-spec get_snapshot(antidote_db:antidote_db(), key(),
+    snapshot_time()) -> {ok, snapshot(), snapshot_time()} | {error, not_found}.
+get_snapshot(AntidoteDB, Key, CommitTime) ->
+    try
+        antidote_db:fold(AntidoteDB,
+            fun({K, V}, AccIn) ->
+                {Key1, VC, SNAP} = binary_to_term(K),
+                case (Key1 == Key) of %% check same key
+                    true ->
+                        %% check its a snapshot and its time is less than the one required
+                        case (SNAP == snap) and
+                            vectorclock:le(vectorclock:from_list(VC), CommitTime) of
+                            true ->
+                                Snapshot = binary_to_term(V),
+                                throw({break, Snapshot, VC});
+                            _ ->
+                                AccIn
+                        end;
+                    false ->
+                        throw({break})
+                end
+            end,
+            [],
+            [{first_key, term_to_binary({Key})}]),
+        {error, not_found}
+    catch
+        {break, SNAP, VC} ->
+            {ok, SNAP, VC};
+        _ ->
+            {error, not_found}
+    end.
+
+%% Saves the snapshot into AntidoteDB
+-spec put_snapshot(antidote_db:antidote_db(), key(), snapshot_time(),
+    snapshot()) -> ok | error.
+put_snapshot(AntidoteDB, Key, SnapshotTime, Snapshot) ->
+    SnapshotTimeList = vectorclock_to_sorted_list(SnapshotTime),
+    antidote_db:put(AntidoteDB, {binary_to_atom(Key), SnapshotTimeList, snap}, Snapshot).
+
+%% Returns a list of operations that have commit time in the range [VCFrom, VCTo]
+-spec get_ops(antidote_db:antidote_db(), key(), vectorclock(), vectorclock()) -> list().
+get_ops(AntidoteDB, Key, VCFrom, VCTo) ->
+    VCFromDict = vectorclock_to_dict(VCFrom),
+    VCToDict = vectorclock_to_dict(VCTo),
+    try
+        antidote_db:fold(AntidoteDB,
+            fun({K, V}, AccIn) ->
+                {Key1, VC1, OP} = binary_to_term(K),
+                VC1Dict = vectorclock:from_list(VC1),
+                case Key == Key1 of %% check same key
+                    true ->
+                        %% if its greater, continue
+                        case vectorclock:gt(VC1Dict, VCToDict) of
+                            true ->
+                                AccIn;
+                            false ->
+                                %% check its an op and its commit time is in the required range
+                                case not vectorclock:lt(VC1Dict, VCFromDict) of
+                                    true ->
+                                        case (OP == op) of
+                                            true ->
+                                                AccIn ++ [binary_to_term(V)];
+                                            false ->
+                                                AccIn
+                                        end;
+                                    false ->
+                                        throw({break, AccIn})
+                                end
+                        end;
+                    false ->
+                        throw({break, AccIn})
+                end
+            end,
+            [],
+            [{first_key, term_to_binary({Key})}])
+    catch
+        {break, OPS} ->
+            OPS;
+        _ ->
+            []
+    end.
+
+%% Saves the operation into AntidoteDB
+-spec put_op(antidote_db:antidote_db(), key(), vectorclock(), operation()) -> ok | error.
+put_op(AntidoteDB, Key, VC, Op) ->
+    VCList = vectorclock_to_sorted_list(VC),
+    antidote_db:put(AntidoteDB, {binary_to_atom(Key), VCList, op}, Op).
+
+vectorclock_to_dict(VC) ->
+    case is_list(VC) of
+        true -> vectorclock:from_list(VC);
+        false -> VC
+    end.
+
+%% Sort the resulting list, for easier comparison and parsing
+vectorclock_to_sorted_list(VC) ->
+    case is_list(VC) of
+        true -> lists:sort(VC);
+        false -> lists:sort(vectorclock:to_list(VC))
+    end.
+
+%% Workaround for basho bench
+%% TODO find a better solution to this
+binary_to_atom(Key) ->
+    case is_binary(Key) of
+        true -> list_to_atom(integer_to_list(binary_to_integer(Key)));
+        false -> Key
+    end.
+
+-ifdef(TEST).
+
+%% This test ensures vectorclock_to_list method
+%% sorts VCs the correct way
+vectorclock_to_sorted_list_test() ->
+    Sorted = vectorclock_to_sorted_list([{e, 5}, {c, 3}, {a, 1}, {b, 2}, {d, 4}]),
+    ?assertEqual([{a, 1}, {b, 2}, {c, 3}, {d, 4}, {e, 5}], Sorted).
+
+get_snapshot_not_found_test() ->
+    eleveldb:destroy("get_snapshot_not_found_test", []),
+    {ok, AntidoteDB} = antidote_db:new("get_snapshot_not_found_test"),
+
+    Key = key,
+    Key1 = key1,
+    Key2 = key2,
+    %% No snapshot in the DB
+    NotFound = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
+    ?assertEqual({error, not_found}, NotFound),
+
+    %% Put 10 snapshots for Key and check there is no snapshot with time 0 in both DCs
+    put_n_snapshots(AntidoteDB, Key, 10),
+    NotFound1 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
+    ?assertEqual({error, not_found}, NotFound1),
+
+    %% Look for a snapshot for Key1
+    S1 = get_snapshot(AntidoteDB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
+    ?assertEqual({error, not_found}, S1),
+
+    %% Put snapshots for Key2 and look for a snapshot for Key1
+    put_n_snapshots(AntidoteDB, Key2, 10),
+    S2 = get_snapshot(AntidoteDB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
+    ?assertEqual({error, not_found}, S2),
+
+    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_not_found_test").
+
+get_snapshot_matching_vc_test() ->
+    eleveldb:destroy("get_snapshot_matching_vc_test", []),
+    {ok, AntidoteDB} = antidote_db:new("get_snapshot_matching_vc_test"),
+
+    Key = key,
+    put_n_snapshots(AntidoteDB, Key, 10),
+
+    %% get some of the snapshots inserted (matches VC)
+    S1 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 1}, {remote, 1}])),
+    S2 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 4}, {remote, 4}])),
+    S3 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 8}, {remote, 8}])),
+    ?assertEqual({ok, 1, [{local, 1}, {remote, 1}]}, S1),
+    ?assertEqual({ok, 4, [{local, 4}, {remote, 4}]}, S2),
+    ?assertEqual({ok, 8, [{local, 8}, {remote, 8}]}, S3),
+
+    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_matching_vc_test").
+
+
+get_snapshot_not_matching_vc_test() ->
+    eleveldb:destroy("get_snapshot_not_matching_vc_test", []),
+    {ok, AntidoteDB} = antidote_db:new("get_snapshot_not_matching_vc_test"),
+
+    Key = key,
+    put_n_snapshots(AntidoteDB, Key, 10),
+
+    %% get snapshots with different times in their DCs
+    S4 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 1}, {remote, 0}])),
+    S5 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 5}, {remote, 4}])),
+    S6 = get_snapshot(AntidoteDB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
+    ?assertEqual({error, not_found}, S4),
+    ?assertEqual({ok, 4, [{local, 4}, {remote, 4}]}, S5),
+    ?assertEqual({ok, 8, [{local, 8}, {remote, 8}]}, S6),
+
+    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_not_matching_vc_test").
+
+get_operations_empty_result_test() ->
+    eleveldb:destroy("get_operations_not_found_test", []),
+    {ok, AntidoteDB} = antidote_db:new("get_operations_not_found_test"),
+    Key = key,
+    Key1 = key1,
+    %% Nothing in the DB yet return empty list
+    O1 = get_ops(AntidoteDB, Key, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
+    ?assertEqual([], O1),
+
+    put_n_operations(AntidoteDB, Key, 10),
+    %% Getting something out of range returns an empty list
+    O2 = get_ops(AntidoteDB, Key, [{local, 123}, {remote, 100}], [{local, 200}, {remote, 124}]),
+    ?assertEqual([], O2),
+
+    %% Getting a key not present, returns an empty list
+    O3 = get_ops(AntidoteDB, Key1, [{local, 2}, {remote, 2}], [{local, 4}, {remote, 5}]),
+    ?assertEqual([], O3),
+
+    %% Searching for the same range returns an empty list
+    O4 = get_ops(AntidoteDB, Key1, [{local, 2}, {remote, 2}], [{local, 2}, {remote, 2}]),
+    ?assertEqual([], O4),
+
+    antidote_db:close_and_destroy(AntidoteDB, "get_operations_not_found_test").
+
+
+get_operations_non_empty_test() ->
+    eleveldb:destroy("get_operations_non_empty_test", []),
+    {ok, AntidoteDB} = antidote_db:new("get_operations_non_empty_test"),
+
+    %% Fill the DB with values
+    Key = key,
+    Key1 = key1,
+    Key2 = key2,
+    put_n_operations(AntidoteDB, Key, 100),
+    put_n_operations(AntidoteDB, Key1, 10),
+    put_n_operations(AntidoteDB, Key2, 25),
+
+    %% concurrent operations are present in the result
+    O1 = get_ops(AntidoteDB, Key1, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
+    O2 = get_ops(AntidoteDB, Key1, [{local, 4}, {remote, 5}], [{local, 7}, {remote, 7}]),
+    ?assertEqual([9, 8, 7, 6, 5, 4, 3, 2], O1),
+    ?assertEqual([7, 6, 5, 4], O2),
+
+    antidote_db:close_and_destroy(AntidoteDB, "get_operations_non_empty_test").
+
+operations_and_snapshots_mixed_test() ->
+    eleveldb:destroy("operations_and_snapshots_mixed_test", []),
+    {ok, AntidoteDB} = antidote_db:new("operations_and_snapshots_mixed_test"),
+
+    Key = key,
+    Key1 = key1,
+    Key2 = key2,
+    VCTo = [{local, 7}, {remote, 8}],
+    put_n_operations(AntidoteDB, Key, 10),
+    put_n_operations(AntidoteDB, Key1, 20),
+    put_snapshot(AntidoteDB, Key1, [{local, 2}, {remote, 3}], 5),
+    put_n_operations(AntidoteDB, Key2, 8),
+
+    %% We want all ops for Key1 that are between the snapshot and
+    %% [{local, 7}, {remote, 8}]. First get the snapshot, then OPS.
+    {ok, Value, VCFrom} = get_snapshot(AntidoteDB, Key1, vectorclock:from_list(VCTo)),
+    ?assertEqual({ok, 5, [{local, 2}, {remote, 3}]}, {ok, Value, VCFrom}),
+
+    O1 = get_ops(AntidoteDB, Key1, VCFrom, VCTo),
+    ?assertEqual([8, 7, 6, 5, 4, 3, 2], O1),
+
+    antidote_db:close_and_destroy(AntidoteDB, "operations_and_snapshots_mixed_test").
+
+%% This test is used to check that compare function for VCs is working OK
+%% with VCs containing != lengths and values
+length_of_vc_test() ->
+    eleveldb:destroy("length_of_vc_test", []),
+    {ok, AntidoteDB} = antidote_db:new("length_of_vc_test"),
+
+    %% Same key, and same value for the local DC
+    %% OP2 should be newer than op1 since it contains 1 more DC in its VC
+    Key = key,
+    put_op(AntidoteDB, Key, [{local, 2}], 1),
+    put_op(AntidoteDB, Key, [{local, 2}, {remote, 3}], 2),
+    O1 = get_ops(AntidoteDB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
+    ?assertEqual([2, 1], O1),
+
+    %% Insert OP3, with no remote DC value and check it´s newer than 1 and 2
+    put_op(AntidoteDB, Key, [{local, 3}], 3),
+    O2 = get_ops(AntidoteDB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
+    ?assertEqual([3, 2, 1], O2),
+
+    %% OP3 is still returned if the local value we look for is lower
+    %% This is the expected outcome for vectorclock gt and lt methods
+    O3 = get_ops(AntidoteDB, Key, [{local, 1}, {remote, 1}], [{local, 2}, {remote, 8}]),
+    ?assertEqual([3, 2, 1], O3),
+
+    %% Insert remote operation not containing local clock and check is the oldest one
+    put_op(AntidoteDB, Key, [{remote, 1}], 4),
+    O4 = get_ops(AntidoteDB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
+    ?assertEqual([3, 2, 1, 4], O4),
+
+    antidote_db:close_and_destroy(AntidoteDB, "length_of_vc_test").
+
+put_n_snapshots(_AntidoteDB, _Key, 0) ->
+    ok;
+put_n_snapshots(AntidoteDB, Key, N) ->
+    put_snapshot(AntidoteDB, Key, [{local, N}, {remote, N}], N),
+    put_n_snapshots(AntidoteDB, Key, N - 1).
+
+put_n_operations(_AntidoteDB, _Key, 0) ->
+    ok;
+put_n_operations(AntidoteDB, Key, N) ->
+    put_op(AntidoteDB, Key, [{local, N}, {remote, N}], N),
+    put_n_operations(AntidoteDB, Key, N - 1).
+
+-endif.

--- a/src/antidote_db_wrapper.erl
+++ b/src/antidote_db_wrapper.erl
@@ -72,7 +72,7 @@ put_snapshot(AntidoteDB, Key, SnapshotTime, Snapshot) ->
     antidote_db:put(AntidoteDB, {binary_to_atom(Key), SnapshotTimeList, snap}, Snapshot).
 
 %% Returns a list of operations that have commit time in the range [VCFrom, VCTo]
--spec get_ops(antidote_db:antidote_db(), key(), vectorclock(), vectorclock()) -> list().
+-spec get_ops(antidote_db:antidote_db(), key(), vectorclock(), vectorclock()) -> [#log_record{}].
 get_ops(AntidoteDB, Key, VCFrom, VCTo) ->
     VCFromDict = vectorclock_to_dict(VCFrom),
     VCToDict = vectorclock_to_dict(VCTo),

--- a/src/leveldb_wrapper.erl
+++ b/src/leveldb_wrapper.erl
@@ -64,7 +64,7 @@ get_ops_applicable_to_snapshot(DB, Key, VectorClock) ->
                 end
             end,
             [],
-            [{first_key, term_to_binary({Key})}]),
+            [{first_key, term_to_binary({Key, vectorclock_to_sorted_list(VectorClock)})}]),
         %% If the fold returned without throwing a break (it iterated all
         %% keys and ended up normally) reverse the resulting list
         {ok, not_found, lists:reverse(Res)}
@@ -100,7 +100,7 @@ get_snapshot(DB, Key, CommitTime) ->
                 end
             end,
             [],
-            [{first_key, term_to_binary({Key})}]),
+            [{first_key, term_to_binary({Key, vectorclock_to_sorted_list(CommitTime)})}]),
         {error, not_found}
     catch
         {break, SNAP} ->
@@ -160,7 +160,7 @@ get_ops(DB, Key, VCFrom, VCTo) ->
                 end
             end,
             #ops_record{ops_list = [], last_vc = vectorclock:new()},
-            [{first_key, term_to_binary({Key})}]),
+            [{first_key, term_to_binary({Key, vectorclock_to_sorted_list(VCTo)})}]),
         %% If the fold returned without throwing a break (it iterated all
         %% keys and ended up normally) reverse the resulting list
         lists:reverse(Res#ops_record.ops_list)

--- a/src/leveldb_wrapper.erl
+++ b/src/leveldb_wrapper.erl
@@ -205,6 +205,17 @@ put(DB, Key, Value) ->
 
 -ifdef(TEST).
 
+withFreshDb(F) ->
+    %% Destroy the test DB to prevent having dirty DBs if a test fails
+    eleveldb:destroy("test_db", []),
+    {ok, AntidoteDB} = antidote_db:new("test_db", leveldb),
+    {leveldb, Db} = AntidoteDB,
+    try
+        F(Db)
+    after
+        antidote_db:close_and_destroy(AntidoteDB, "test_db")
+    end.
+
 %% This test ensures vectorclock_to_list method
 %% sorts VCs the correct way
 vectorclock_to_sorted_list_test() ->
@@ -212,221 +223,217 @@ vectorclock_to_sorted_list_test() ->
     ?assertEqual([{a, 1}, {b, 2}, {c, 3}, {d, 4}, {e, 5}], Sorted).
 
 get_ops_applicable_to_snapshot_empty_result_test() ->
-    eleveldb:destroy("get_ops_applicable_to_snapshot_empty_result_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_ops_applicable_to_snapshot_empty_result_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        Key = key,
 
-    Key = key,
+        %% There are no ops nor snapshots in the DB
+        NotFound = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 3}, {remote, 2}])),
+        ?assertEqual({ok, not_found, []}, NotFound),
 
-    NotFound = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 3}, {remote, 2}])),
-    ?assertEqual({ok, not_found, []}, NotFound),
+        %% Add a new Snapshot, but it's not in the range searched, so the result is still empty
+        VC = vectorclock:from_list([{local, 4}, {remote, 4}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC, value = 1}),
 
-    VC = vectorclock:from_list([{local, 4}, {remote, 4}]),
-    put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC, value = 1}),
-    S1 = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 3}, {remote, 3}])),
-    ?assertEqual({ok, not_found, []}, S1),
-
-    antidote_db:close_and_destroy(AntidoteDB, "get_ops_applicable_to_snapshot_empty_result_test").
+        S1 = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 3}, {remote, 3}])),
+        ?assertEqual({ok, not_found, []}, S1)
+                end).
 
 get_ops_applicable_to_snapshot_non_empty_result_test() ->
-    eleveldb:destroy("get_ops_applicable_to_snapshot_non_empty_result_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_ops_applicable_to_snapshot_non_empty_result_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        Key = key,
+        Key1 = key1,
 
-    Key = key,
-    Key1 = key1,
+        %% Save two snapshots
+        VC = vectorclock:from_list([{local, 4}, {remote, 4}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC, value = 1}),
+        VC1 = vectorclock:from_list([{local, 2}, {remote, 2}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC1, value = 2}),
 
-    VC = vectorclock:from_list([{local, 4}, {remote, 4}]),
-    put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC, value = 1}),
-    VC1 = vectorclock:from_list([{local, 2}, {remote, 2}]),
-    put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC1, value = 2}),
-    {ok, S1, Ops1} = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 5}, {remote, 6}])),
-    ?assertEqual(1, S1#materialized_snapshot.value),
-    ?assertEqual([], Ops1),
+        %% There is one [4, 4] snapshot matches best so it's returned with no ops since there aren't any
+        {ok, S1, Ops1} = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
+        ?assertEqual(1, S1#materialized_snapshot.value),
+        ?assertEqual([], Ops1),
 
-    put_n_operations(DB, Key, 10),
-    put_n_operations(DB, Key1, 5),
+        %% Add some ops, and try again with the same VC. Now ops to be applied are returned
+        put_n_operations(DB, Key, 10),
+        put_n_operations(DB, Key1, 5),
 
-    {ok, S2, Ops2} = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
-    ?assertEqual(1, S2#materialized_snapshot.value),
-    ?assertEqual([8, 7, 6, 5, 4], filter_records_into_numbers(Ops2)),
-
-    antidote_db:close_and_destroy(AntidoteDB, "get_ops_applicable_to_snapshot_non_empty_result_test").
+        {ok, S2, Ops2} = get_ops_applicable_to_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
+        ?assertEqual(1, S2#materialized_snapshot.value),
+        ?assertEqual([8, 7, 6, 5, 4], filter_records_into_numbers(Ops2))
+                end).
 
 get_snapshot_not_found_test() ->
-    eleveldb:destroy("get_snapshot_not_found_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_snapshot_not_found_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        Key = key,
+        Key1 = key1,
+        Key2 = key2,
 
-    Key = key,
-    Key1 = key1,
-    Key2 = key2,
-    %% No snapshot in the DB
-    NotFound = get_snapshot(DB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
-    ?assertEqual({error, not_found}, NotFound),
+        %% No snapshot in the DB
+        NotFound = get_snapshot(DB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
+        ?assertEqual({error, not_found}, NotFound),
 
-    %% Put 10 snapshots for Key and check there is no snapshot with time 0 in both DCs
-    put_n_snapshots(DB, Key, 10),
-    NotFound1 = get_snapshot(DB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
-    ?assertEqual({error, not_found}, NotFound1),
+        %% Put 10 snapshots for Key and check there is no snapshot with time 0 in both DCs
+        put_n_snapshots(DB, Key, 10),
+        NotFound1 = get_snapshot(DB, Key, vectorclock:from_list([{local, 0}, {remote, 0}])),
+        ?assertEqual({error, not_found}, NotFound1),
 
-    %% Look for a snapshot for Key1
-    S1 = get_snapshot(DB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
-    ?assertEqual({error, not_found}, S1),
+        %% Look for a snapshot for Key1
+        S1 = get_snapshot(DB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
+        ?assertEqual({error, not_found}, S1),
 
-    %% Put snapshots for Key2 and look for a snapshot for Key1
-    put_n_snapshots(DB, Key2, 10),
-    S2 = get_snapshot(DB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
-    ?assertEqual({error, not_found}, S2),
-
-    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_not_found_test").
+        %% Put snapshots for Key2 and look for a snapshot for Key1
+        put_n_snapshots(DB, Key2, 10),
+        S2 = get_snapshot(DB, Key1, vectorclock:from_list([{local, 5}, {remote, 4}])),
+        ?assertEqual({error, not_found}, S2)
+                end).
 
 get_snapshot_matching_vc_test() ->
-    eleveldb:destroy("get_snapshot_matching_vc_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_snapshot_matching_vc_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
 
-    Key = key,
-    put_n_snapshots(DB, Key, 10),
+        Key = key,
+        put_n_snapshots(DB, Key, 10),
 
-    %% get some of the snapshots inserted (matches VC)
-    {ok, S1} = get_snapshot(DB, Key, vectorclock:from_list([{local, 1}, {remote, 1}])),
-    {ok, S2} = get_snapshot(DB, Key, vectorclock:from_list([{local, 4}, {remote, 4}])),
-    {ok, S3} = get_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 8}])),
-    ?assertEqual([{local, 1}, {remote, 1}], vectorclock_to_sorted_list(S1#materialized_snapshot.snapshot_time)),
-    ?assertEqual(1, S1#materialized_snapshot.value),
-    ?assertEqual([{local, 4}, {remote, 4}], vectorclock_to_sorted_list(S2#materialized_snapshot.snapshot_time)),
-    ?assertEqual(4, S2#materialized_snapshot.value),
-    ?assertEqual([{local, 8}, {remote, 8}], vectorclock_to_sorted_list(S3#materialized_snapshot.snapshot_time)),
-    ?assertEqual(8, S3#materialized_snapshot.value),
+        %% Get some of the snapshots inserted (matching VC)
+        {ok, S1} = get_snapshot(DB, Key, vectorclock:from_list([{local, 1}, {remote, 1}])),
+        {ok, S2} = get_snapshot(DB, Key, vectorclock:from_list([{local, 4}, {remote, 4}])),
+        {ok, S3} = get_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 8}])),
 
-    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_matching_vc_test").
+        ?assertEqual([{local, 1}, {remote, 1}], vectorclock_to_sorted_list(S1#materialized_snapshot.snapshot_time)),
+        ?assertEqual(1, S1#materialized_snapshot.value),
+
+        ?assertEqual([{local, 4}, {remote, 4}], vectorclock_to_sorted_list(S2#materialized_snapshot.snapshot_time)),
+        ?assertEqual(4, S2#materialized_snapshot.value),
+
+        ?assertEqual([{local, 8}, {remote, 8}], vectorclock_to_sorted_list(S3#materialized_snapshot.snapshot_time)),
+        ?assertEqual(8, S3#materialized_snapshot.value)
+                end).
 
 
 get_snapshot_not_matching_vc_test() ->
-    eleveldb:destroy("get_snapshot_not_matching_vc_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_snapshot_not_matching_vc_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        Key = key,
 
-    Key = key,
-    put_n_snapshots(DB, Key, 10),
+        %% Add 3 snapshots
+        VC = vectorclock:from_list([{local, 4}, {remote, 4}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC, value = 4}),
 
-    %% get snapshots with different times in their DCs
-    S4 = get_snapshot(DB, Key, vectorclock:from_list([{local, 1}, {remote, 0}])),
-    {ok, S5} = get_snapshot(DB, Key, vectorclock:from_list([{local, 5}, {remote, 4}])),
-    {ok, S6} = get_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
-    ?assertEqual({error, not_found}, S4),
-    ?assertEqual([{local, 4}, {remote, 4}], vectorclock_to_sorted_list(S5#materialized_snapshot.snapshot_time)),
-    ?assertEqual(4, S5#materialized_snapshot.value),
-    ?assertEqual([{local, 8}, {remote, 8}], vectorclock_to_sorted_list(S6#materialized_snapshot.snapshot_time)),
-    ?assertEqual(8, S6#materialized_snapshot.value),
 
-    antidote_db:close_and_destroy(AntidoteDB, "get_snapshot_not_matching_vc_test").
+        VC1 = vectorclock:from_list([{local, 2}, {remote, 3}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC1, value = 2}),
+
+
+        VC2 = vectorclock:from_list([{local, 8}, {remote, 7}]),
+        put_snapshot(DB, Key, #materialized_snapshot{snapshot_time = VC2, value = 8}),
+
+        %% Request the snapshots using a VC different than the one used to insert them
+        S4 = get_snapshot(DB, Key, vectorclock:from_list([{local, 1}, {remote, 0}])),
+        {ok, S5} = get_snapshot(DB, Key, vectorclock:from_list([{local, 6}, {remote, 5}])),
+        {ok, S6} = get_snapshot(DB, Key, vectorclock:from_list([{local, 8}, {remote, 9}])),
+
+        ?assertEqual({error, not_found}, S4),
+
+        ?assertEqual([{local, 4}, {remote, 4}], vectorclock_to_sorted_list(S5#materialized_snapshot.snapshot_time)),
+        ?assertEqual(4, S5#materialized_snapshot.value),
+
+        ?assertEqual([{local, 8}, {remote, 7}], vectorclock_to_sorted_list(S6#materialized_snapshot.snapshot_time)),
+        ?assertEqual(8, S6#materialized_snapshot.value)
+                end).
 
 get_operations_empty_result_test() ->
-    eleveldb:destroy("get_operations_not_found_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_operations_not_found_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
-    Key = key,
-    Key1 = key1,
-    %% Nothing in the DB yet return empty list
-    O1 = get_ops(DB, Key, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
-    ?assertEqual([], O1),
+    withFreshDb(fun(DB) ->
+        Key = key,
+        Key1 = key1,
 
-    put_n_operations(DB, Key, 10),
-    %% Getting something out of range returns an empty list
-    O2 = get_ops(DB, Key, [{local, 123}, {remote, 100}], [{local, 200}, {remote, 124}]),
-    ?assertEqual([], O2),
+        %% Nothing in the DB returns an empty list
+        O1 = get_ops(DB, Key, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
+        ?assertEqual([], O1),
 
-    %% Getting a key not present, returns an empty list
-    O3 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 4}, {remote, 5}]),
-    ?assertEqual([], O3),
+        %% Insert some operations
+        put_n_operations(DB, Key, 10),
 
-    %% Searching for the same range returns an empty list
-    O4 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 2}, {remote, 2}]),
-    ?assertEqual([], O4),
+        %% Requesting for ops in a range with noting, returns an empty list
+        O2 = get_ops(DB, Key, [{local, 123}, {remote, 100}], [{local, 200}, {remote, 124}]),
+        ?assertEqual([], O2),
 
-    antidote_db:close_and_destroy(AntidoteDB, "get_operations_not_found_test").
+        %% Getting a key not present, returns an empty list
+        O3 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 4}, {remote, 5}]),
+        ?assertEqual([], O3),
+
+        %% Searching for the same range returns an empty list
+        O4 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 2}, {remote, 2}]),
+        ?assertEqual([], O4)
+                end).
 
 
 get_operations_non_empty_test() ->
-    eleveldb:destroy("get_operations_non_empty_test", []),
-    {ok, AntidoteDB} = antidote_db:new("get_operations_non_empty_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        %% Fill the DB with values
+        Key = key,
+        Key1 = key1,
+        Key2 = key2,
 
-    %% Fill the DB with values
-    Key = key,
-    Key1 = key1,
-    Key2 = key2,
-    put_n_operations(DB, Key, 100),
-    put_n_operations(DB, Key1, 10),
-    put_n_operations(DB, Key2, 25),
+        put_n_operations(DB, Key, 100),
+        put_n_operations(DB, Key1, 10),
+        put_n_operations(DB, Key2, 25),
 
-    %% concurrent operations are present in the result
-    O1 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
-    ?assertEqual([8, 7, 6, 5, 4, 3, 2], filter_records_into_numbers(O1)),
+        %% Concurrent operations int the lower bound are present in the result
+        O1 = get_ops(DB, Key1, [{local, 2}, {remote, 2}], [{local, 8}, {remote, 9}]),
+        ?assertEqual([8, 7, 6, 5, 4, 3, 2], filter_records_into_numbers(O1)),
 
-    O2 = get_ops(DB, Key1, [{local, 4}, {remote, 5}], [{local, 7}, {remote, 7}]),
-    ?assertEqual([7, 6, 5, 4], filter_records_into_numbers(O2)),
-
-    antidote_db:close_and_destroy(AntidoteDB, "get_operations_non_empty_test").
+        O2 = get_ops(DB, Key1, [{local, 4}, {remote, 5}], [{local, 7}, {remote, 7}]),
+        ?assertEqual([7, 6, 5, 4], filter_records_into_numbers(O2))
+                end).
 
 operations_and_snapshots_mixed_test() ->
-    eleveldb:destroy("operations_and_snapshots_mixed_test", []),
-    {ok, AntidoteDB} = antidote_db:new("operations_and_snapshots_mixed_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        Key = key,
+        Key1 = key1,
+        Key2 = key2,
 
-    Key = key,
-    Key1 = key1,
-    Key2 = key2,
-    VCTo = [{local, 7}, {remote, 8}],
-    put_n_operations(DB, Key, 10),
-    put_n_operations(DB, Key1, 20),
-    put_snapshot(DB, Key1, #materialized_snapshot{snapshot_time = [{local, 2}, {remote, 3}], value = 5}),
-    put_n_operations(DB, Key2, 8),
+        VCTo = [{local, 7}, {remote, 8}],
+        put_n_operations(DB, Key, 10),
+        put_n_operations(DB, Key1, 20),
+        put_snapshot(DB, Key1, #materialized_snapshot{snapshot_time = [{local, 2}, {remote, 3}], value = 5}),
+        put_n_operations(DB, Key2, 8),
 
-    %% We want all ops for Key1 that are between the snapshot and
-    %% [{local, 7}, {remote, 8}]. First get the snapshot, then OPS.
-    {ok, Snapshot} = get_snapshot(DB, Key1, vectorclock:from_list(VCTo)),
-    ?assertEqual([{local, 2}, {remote, 3}], vectorclock_to_sorted_list(Snapshot#materialized_snapshot.snapshot_time)),
-    ?assertEqual(5, Snapshot#materialized_snapshot.value),
+        %% We want all ops for Key1 that are between the snapshot and
+        %% [{local, 7}, {remote, 8}]. First get the snapshot, then OPS.
+        {ok, Snapshot} = get_snapshot(DB, Key1, vectorclock:from_list(VCTo)),
+        ?assertEqual([{local, 2}, {remote, 3}], vectorclock_to_sorted_list(Snapshot#materialized_snapshot.snapshot_time)),
+        ?assertEqual(5, Snapshot#materialized_snapshot.value),
 
-    O1 = get_ops(DB, Key1, Snapshot#materialized_snapshot.snapshot_time, VCTo),
-    ?assertEqual([7, 6, 5, 4, 3, 2], filter_records_into_numbers(O1)),
-
-    antidote_db:close_and_destroy(AntidoteDB, "operations_and_snapshots_mixed_test").
+        O1 = get_ops(DB, Key1, Snapshot#materialized_snapshot.snapshot_time, VCTo),
+        ?assertEqual([7, 6, 5, 4, 3, 2], filter_records_into_numbers(O1))
+                end).
 
 %% This test is used to check that compare function for VCs is working OK
 %% with VCs containing != lengths and values
 length_of_vc_test() ->
-    eleveldb:destroy("length_of_vc_test", []),
-    {ok, AntidoteDB} = antidote_db:new("length_of_vc_test", leveldb),
-    {leveldb, DB} = AntidoteDB,
+    withFreshDb(fun(DB) ->
+        %% Same key, and same value for the local DC
+        %% OP2 should be newer than op1 since it contains 1 more DC in its VC
+        Key = key,
+        put_op(DB, Key, [{local, 2}], #log_record{version = 1}),
+        put_op(DB, Key, [{local, 2}, {remote, 3}], #log_record{version = 2}),
+        O1 = filter_records_into_numbers(get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}])),
+        ?assertEqual([2, 1], O1),
 
-    %% Same key, and same value for the local DC
-    %% OP2 should be newer than op1 since it contains 1 more DC in its VC
-    Key = key,
-    put_op(DB, Key, [{local, 2}], #log_record{version = 1}),
-    put_op(DB, Key, [{local, 2}, {remote, 3}], #log_record{version = 2}),
-    O1 = filter_records_into_numbers(get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}])),
-    ?assertEqual([2, 1], O1),
+        %% Insert OP3, with no remote DC value and check it´s newer than 1 and 2
+        put_op(DB, Key, [{local, 3}], #log_record{version = 3}),
+        O2 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
+        ?assertEqual([3, 2, 1], filter_records_into_numbers(O2)),
 
-    %% Insert OP3, with no remote DC value and check it´s newer than 1 and 2
-    put_op(DB, Key, [{local, 3}], #log_record{version = 3}),
-    O2 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
-    ?assertEqual([3, 2, 1], filter_records_into_numbers(O2)),
+        %% OP3 is still returned if the local value we look for is lower
+        %% This is the expected outcome for vectorclock gt and lt methods
+        O3 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 2}, {remote, 8}]),
+        ?assertEqual([3, 2, 1], filter_records_into_numbers(O3)),
 
-    %% OP3 is still returned if the local value we look for is lower
-    %% This is the expected outcome for vectorclock gt and lt methods
-    O3 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 2}, {remote, 8}]),
-    ?assertEqual([3, 2, 1], filter_records_into_numbers(O3)),
-
-    %% Insert remote operation not containing local clock and check is the oldest one
-    put_op(DB, Key, [{remote, 1}], #log_record{version = 4}),
-    O4 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
-    ?assertEqual([3, 2, 1, 4], filter_records_into_numbers(O4)),
-
-    antidote_db:close_and_destroy(AntidoteDB, "length_of_vc_test").
+        %% Insert remote operation not containing local clock and check is the oldest one
+        put_op(DB, Key, [{remote, 1}], #log_record{version = 4}),
+        O4 = get_ops(DB, Key, [{local, 1}, {remote, 1}], [{local, 7}, {remote, 8}]),
+        ?assertEqual([3, 2, 1, 4], filter_records_into_numbers(O4))
+                end).
 
 put_n_snapshots(_DB, _Key, 0) ->
     ok;


### PR DESCRIPTION
This first PR, contains the initial implementation of the elevledb version of antidote_db. In the future, other PRs, will include the possibility to use the old logging vnode and disk_log implementation. 

The antidote_db module contains a basic API to interact with eleveldb. The leveldb_wrapper module, contains a wrapper of the API provided by eleveldb, with added code containing Antidote logic.

Here is an overview of the new architecture proposed:

![antidotedb future](https://cloud.githubusercontent.com/assets/2179572/18692804/2e475c58-7f73-11e6-9e25-5923dffaf09c.png)
